### PR TITLE
Maximum repetition count and sequence time

### DIFF
--- a/src/Extensions/DataSchema.Generated.cs
+++ b/src/Extensions/DataSchema.Generated.cs
@@ -412,6 +412,8 @@ namespace DataSchema
     
         private int _repeatCount = 1;
     
+        private double _maximumTime = 10D;
+    
         private System.Collections.Generic.List<System.Collections.Generic.List<Valence>> _rewardCondition1 = new System.Collections.Generic.List<System.Collections.Generic.List<Valence>>();
     
         private System.Collections.Generic.List<System.Collections.Generic.List<Valence>> _rewardCondition2 = new System.Collections.Generic.List<System.Collections.Generic.List<Valence>>();
@@ -433,6 +435,7 @@ namespace DataSchema
             _interCommandTime = other._interCommandTime;
             _interTrialInterval = other._interTrialInterval;
             _repeatCount = other._repeatCount;
+            _maximumTime = other._maximumTime;
             _rewardCondition1 = other._rewardCondition1;
             _rewardCondition2 = other._rewardCondition2;
             _enableTrialIndicator = other._enableTrialIndicator;
@@ -558,6 +561,23 @@ namespace DataSchema
             }
         }
     
+        /// <summary>
+        /// The maximum time in seconds that a sequence can last
+        /// </summary>
+        [YamlDotNet.Serialization.YamlMemberAttribute(Alias="maximumTime")]
+        [System.ComponentModel.DescriptionAttribute("The maximum time in seconds that a sequence can last")]
+        public double MaximumTime
+        {
+            get
+            {
+                return _maximumTime;
+            }
+            set
+            {
+                _maximumTime = value;
+            }
+        }
+    
         [System.Xml.Serialization.XmlIgnoreAttribute()]
         [YamlDotNet.Serialization.YamlMemberAttribute(Alias="rewardCondition1")]
         public System.Collections.Generic.List<System.Collections.Generic.List<Valence>> RewardCondition1
@@ -640,6 +660,7 @@ namespace DataSchema
             stringBuilder.Append("interCommandTime = " + _interCommandTime + ", ");
             stringBuilder.Append("interTrialInterval = " + _interTrialInterval + ", ");
             stringBuilder.Append("repeatCount = " + _repeatCount + ", ");
+            stringBuilder.Append("maximumTime = " + _maximumTime + ", ");
             stringBuilder.Append("rewardCondition1 = " + _rewardCondition1 + ", ");
             stringBuilder.Append("rewardCondition2 = " + _rewardCondition2 + ", ");
             stringBuilder.Append("enableTrialIndicator = " + _enableTrialIndicator + ", ");

--- a/src/SequenceSandbox.bonsai
+++ b/src/SequenceSandbox.bonsai
@@ -646,7 +646,7 @@
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:RepeatCount">
-                <rx:Count>10</rx:Count>
+                <rx:Count>5</rx:Count>
               </Combinator>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
@@ -680,6 +680,34 @@
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:Repeat" />
             </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>CurrentSequence</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>MaximumTime</Selector>
+            </Expression>
+            <Expression xsi:type="scr:ExpressionTransform">
+              <scr:Expression>TimeSpan.FromSeconds(it)</scr:Expression>
+            </Expression>
+            <Expression xsi:type="PropertyMapping">
+              <PropertyMappings>
+                <Property Name="DueTime" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Timer">
+                <rx:DueTime>PT0S</rx:DueTime>
+                <rx:Period>PT0S</rx:Period>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="BooleanProperty">
+                <Value>false</Value>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Merge" />
+            </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:TakeUntil" />
             </Expression>
@@ -711,7 +739,7 @@
             <Edge From="12" To="13" Label="Source1" />
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="14" To="15" Label="Source2" />
-            <Edge From="15" To="25" Label="Source1" />
+            <Edge From="15" To="32" Label="Source1" />
             <Edge From="16" To="21" Label="Source1" />
             <Edge From="17" To="18" Label="Source1" />
             <Edge From="18" To="19" Label="Source1" />
@@ -720,10 +748,17 @@
             <Edge From="21" To="23" Label="Source1" />
             <Edge From="22" To="23" Label="Source2" />
             <Edge From="23" To="24" Label="Source1" />
-            <Edge From="24" To="25" Label="Source2" />
+            <Edge From="24" To="31" Label="Source1" />
             <Edge From="25" To="26" Label="Source1" />
             <Edge From="26" To="27" Label="Source1" />
             <Edge From="27" To="28" Label="Source1" />
+            <Edge From="28" To="29" Label="Source1" />
+            <Edge From="29" To="30" Label="Source1" />
+            <Edge From="30" To="31" Label="Source2" />
+            <Edge From="31" To="32" Label="Source2" />
+            <Edge From="32" To="33" Label="Source1" />
+            <Edge From="33" To="34" Label="Source1" />
+            <Edge From="34" To="35" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/SequenceSandbox.bonsai.layout
+++ b/src/SequenceSandbox.bonsai.layout
@@ -1196,6 +1196,90 @@
         </Size>
         <WindowState>Normal</WindowState>
       </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
     </EditorVisualizerLayout>
   </DialogSettings>
   <DialogSettings>
@@ -1571,8 +1655,8 @@
     <VisualizerSettings>
       <TimeSeriesVisualizer>
         <Capacity>640</Capacity>
-        <Min>0</Min>
-        <Max>1.1</Max>
+        <Min>0.95</Min>
+        <Max>1.05</Max>
         <AutoScale>true</AutoScale>
       </TimeSeriesVisualizer>
     </VisualizerSettings>

--- a/src/data-schema.json
+++ b/src/data-schema.json
@@ -130,8 +130,13 @@
                 },
                 "repeatCount": {
                     "description": "Integer specifying how many times a sequence is allowed to repeat",
-                    "default": "1",
+                    "default": 1,
                     "type": "integer"
+                },
+                "maximumTime": {
+                    "description": "The maximum time in seconds that a sequence can last",
+                    "default": 10,
+                    "type": "number"
                 },
                 "rewardCondition1": {
                     "items": {

--- a/src/hypnose-session.yml
+++ b/src/hypnose-session.yml
@@ -26,7 +26,8 @@ sequences:
     presentationTime: 0.8,
     interCommand: Purge,
     interCommandTime: 0.2,
-    repeatCount: 5,
+    repeatCount: 20,
+    maximumTime: 5,
     rewardCondition1: [
       [{command: OdorA, rewarded: True}, {command: OdorB, rewarded: False}, {command: OdorC, rewarded: False}, {command: OdorD, rewarded: False}, {command: OdorE, rewarded: False}, {command: OdorF, rewarded: False}, {command: OdorG, rewarded: False}],
     ],


### PR DESCRIPTION
This PR addresses issue #6 and adds schema parameters for repeat count and maximum sequence time.

For a repeatCount of 1, a sequence will proceed as normal.
For a repeatCount >1, the sequence will run the total number of times given in repeatCount while the subject is still engaged.
A sequence will terminate after the maximumTime value has elapsed.